### PR TITLE
Add editorconfig

### DIFF
--- a/.editoronfig
+++ b/.editoronfig
@@ -1,0 +1,13 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Editorconfig lets us have standard editor settings for things like whitespace.

This is a minor commit but worth a review in case there are any config settings that we want to discuss / add / edit.