### PR TITLE
Enable flag list

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "extends": "airbnb",
   "parser": "babel-eslint",
   "rules": {
-    "semi": [2, "never"]
+    "semi": [2, "never"],
+    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
   },
   "env": {
     "es6": true,

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ typings/
 
 .cache
 dist
+
+# Make sure we don't commit the word list
+# (since it isn't ours to share)
+src/public/data.json

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "concurrently 'yarn build:node' 'yarn build:parcel'",
     "build:node": "babel src -d lib",
     "build:parcel": "./node_modules/.bin/parcel build src/client/index.html",
-    "lint": "./node_modules/.bin/eslint 'src/**'",
+    "lint": "./node_modules/.bin/eslint 'src/**/*.js'",
     "test": ""
   },
   "devDependencies": {

--- a/src/client/components/App.js
+++ b/src/client/components/App.js
@@ -7,8 +7,10 @@ import Header from './Header'
 import Sidebar from './Sidebar'
 import Editor from './Editor'
 
-// Styles
+// Data Imports
+import fullPhraseList from '../../public/data.json'
 
+// Styles
 const HeaderWrapper = styled.div`
   margin: 70px 40px;
   margin-bottom: 25px;
@@ -44,26 +46,13 @@ class App extends React.Component {
     // Eventually this will be an API call.
     // Until then we simulate with a promise.
     return new Promise((resolve, reject) => {
-      const flaggedPhrases = [
-        {
-          id: 0,
-          text: "pants",
-          dCount: Math.random() * 100,
-          rCount: Math.random() * 100,
-        },
-        {
-          id: 1,
-          text: "thinking face",
-          dCount: Math.random() * 100,
-          rCount: Math.random() * 100,
-        },
-        {
-          id: 2,
-          text: "emoji",
-          dCount: Math.random() * 100,
-          rCount: Math.random() * 100,
-        },
-      ]
+      const flaggedPhrases = fullPhraseList.reduce((flags, phrase) => {
+        if(sourceText.toLowerCase().indexOf(phrase.text.toLowerCase()) != -1) {
+          flags.push(phrase)
+          return flags
+        }
+        return flags
+      }, [])
       resolve(flaggedPhrases)
     })
   }

--- a/src/client/components/App.js
+++ b/src/client/components/App.js
@@ -32,8 +32,8 @@ class App extends React.Component {
   state = {
     articleText: "",
     flaggedPhrases: [],
-    selectedPhrase: {},
-    flagToggleState: false,
+    selectedPhrase: null,
+    flagToggleState: true,
     aboutToggleState: false,
     reviewToggleState: false,
   }
@@ -50,7 +50,19 @@ class App extends React.Component {
           text: "pants",
           dCount: Math.random() * 100,
           rCount: Math.random() * 100,
-        }
+        },
+        {
+          id: 1,
+          text: "thinking face",
+          dCount: Math.random() * 100,
+          rCount: Math.random() * 100,
+        },
+        {
+          id: 2,
+          text: "emoji",
+          dCount: Math.random() * 100,
+          rCount: Math.random() * 100,
+        },
       ]
       resolve(flaggedPhrases)
     })

--- a/src/client/components/Editor/index.js
+++ b/src/client/components/Editor/index.js
@@ -127,9 +127,8 @@ class Editor extends React.Component {
       setSelectedPhrase,
     } = this.props
     const needle = phrase.text
-    const cleanedText = text.replace(/\n$/g, '\n\n')
     const processedText = reactStringReplace(
-      cleanedText,
+      text,
       needle,
       (match, i) => (
         <FlaggedPhrase
@@ -150,7 +149,7 @@ class Editor extends React.Component {
       flaggedPhrases,
     } = this.props
 
-    let modifiedText = articleText
+    let modifiedText = articleText.replace(/\n$/g, '\n\n')
     flaggedPhrases.map((phrase) => {
       modifiedText = this.insertFlaggedPhrases(modifiedText, phrase)
     })

--- a/src/client/components/Sidebar/ListPane/FlagCard.js
+++ b/src/client/components/Sidebar/ListPane/FlagCard.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+// App Imports
+import { phraseType } from '../../../types'
+import { calculatePhraseColor } from '../../../helpers'
+
+// Styles
+
+const Wrapper = styled.div`
+  border: 1px solid black;
+  width: 100%;
+  height: 82px;
+  padding: 15px;
+  margin-top: 20px;
+  box-shadow: 2px 2px 0 0 ${props => calculatePhraseColor(props.phrase)};
+`
+
+const FlagText = styled.div`
+  font-family: "Roboto Slab";
+  font-size: 22px;
+  font-weight: 300;
+`
+
+// Component
+class FlagCard extends React.Component {
+  static propTypes = {
+    flaggedPhrase: phraseType,
+  }
+
+  render() {
+    const { flaggedPhrase } = this.props
+    return (
+      <>
+        <Wrapper
+          phrase={flaggedPhrase}
+        >
+          <FlagText>
+            { flaggedPhrase.text }
+          </FlagText>
+        </Wrapper>
+      </>
+    )
+  }
+}
+
+export default FlagCard

--- a/src/client/components/Sidebar/ListPane/FlagCount.js
+++ b/src/client/components/Sidebar/ListPane/FlagCount.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+// App Imports
+
+// Styles
+const Wrapper = styled.div`
+  display: flex;
+`
+
+const Total = styled.div`
+  font-family: Roboto;
+  font-size: 54px;
+  font-weight: 100;
+  line-height: 72px;
+`
+
+const Label = styled.div`
+  font-family: Roboto;
+  font-size: 18px;
+  width: 86px;
+  height: 46px;
+  line-height: 24px;
+  text-transform: uppercase;
+  padding: 10px;
+`
+
+// Component
+class FlagCount extends React.Component {
+  static propTypes = {
+    flaggedPhrases: PropTypes.array,
+  }
+
+  render() {
+    const { flaggedPhrases } = this.props
+    const count = flaggedPhrases.length
+    return (
+      <>
+        <Wrapper>
+          <Total>{count}</Total>
+          <Label>Flagged<br/>Phrase{count==1?"":"s"}</Label>
+        </Wrapper>
+      </>
+    )
+  }
+}
+
+export default FlagCount

--- a/src/client/components/Sidebar/ListPane/index.js
+++ b/src/client/components/Sidebar/ListPane/index.js
@@ -1,15 +1,38 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
 // App Imports
+import FlagCard from './FlagCard'
+import FlagCount from './FlagCount'
 
+// Styles
+const FlagList = styled.div`
+  border-top: 1px solid black;
+  padding: 10px 0px;
+`
 
+// Component
 class ListPane extends React.Component {
+  static propTypes = {
+    flaggedPhrases: PropTypes.array,
+  }
+
   render() {
+    const { flaggedPhrases } = this.props
     return (
       <>
         <div>
-          List Pane
+          <FlagCount
+            flaggedPhrases={flaggedPhrases}
+          />
+          <FlagList>
+            { flaggedPhrases.map(flaggedPhrase => (
+              <FlagCard
+                flaggedPhrase={flaggedPhrase}
+              />
+            ))}
+          </FlagList>
         </div>
       </>
     )

--- a/src/client/components/Sidebar/index.js
+++ b/src/client/components/Sidebar/index.js
@@ -12,9 +12,8 @@ import ListPane from './ListPane'
 
 // Styles
 const PaneWrapper = styled.div`
-  padding: 40px;
-  width: 30%;
-  height: 100%;
+  padding: 0px 40px;
+  width: 100%;
 `
 
 // Component

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Truth Goggles: Language Checker</title>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:300|Roboto:300,400" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:300|Roboto:100,300,400" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/public/example.data.json
+++ b/src/public/example.data.json
@@ -1,1 +1,14 @@
-[{"id":1,"text":"pants","dCount":0,"rCount":15},{"id":2,"text":"thinking face","dCount":26,"rCount":10}]
+[
+  {
+    "id": 1,
+    "text": "pants",
+    "dCount": 0,
+    "rCount": 15
+  },
+  {
+    "id": 2,
+    "text": "thinking face",
+    "dCount": 26,
+    "rCount": 10
+  }
+]

--- a/src/public/example.data.json
+++ b/src/public/example.data.json
@@ -1,0 +1,1 @@
+[{"id":1,"text":"pants","dCount":0,"rCount":15},{"id":2,"text":"thinking face","dCount":26,"rCount":10}]


### PR DESCRIPTION
We now render a list of identified phrases which appear as the user types.  The list does NOT account for the size of the text area, and it renders all phrases flagged in the entire document.  It also does not currently render the flag types and instance counts as per the visual spec.

This also adds support for real data (though it doesn't gracefully handle missing data -- that's because eventually we are hopeful to be able to commit a baseline dataset directly)

<img width="1354" alt="image" src="https://user-images.githubusercontent.com/208884/54573619-6ac11580-49c3-11e9-813b-c6e7e09143ac.png">
